### PR TITLE
Improve search tolerance & add context lengths

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,8 @@
     <option value="10">10</option>
     <option value="100">100</option>
     <option value="1000" selected>1,000</option>
+    <option value="2000">2,000</option>
+    <option value="3000">3,000</option>
     <option value="10000">10,000</option>
     <option value="100000">100,000</option>
   </select>
@@ -110,6 +112,8 @@
     let boundaryIndices = []; // word indices marking chapter starts
 
     const textFileRegex = /\.(xhtml|html|htm|txt)$/i;
+
+    const stripPunctuation = s => s.replace(/[\p{P}\p{S}]+/gu, '');
 
     // Helpers
     const preventDefaults = e => { e.preventDefault(); e.stopPropagation(); };
@@ -161,7 +165,7 @@
               if (originalWords.length !== 0) boundaryIndices.push(originalWords.length);
             } else {
               originalWords.push(word);
-              lowerWords.push(word.toLowerCase());
+              lowerWords.push(stripPunctuation(word).toLowerCase());
             }
           }
         }
@@ -193,8 +197,10 @@
       if (!quote) { outputArea.value = ''; return; }
 
       const radius = Math.max(1, parseInt(contextSelect.value, 10));
-      const quoteWords = quote.replace(/\s+/g, ' ').split(' ');
-      const lowerQuoteWords = quoteWords.map(w => w.toLowerCase());
+      const lowerQuoteWords = quote
+        .replace(/\s+/g, ' ')
+        .split(' ')
+        .map(w => stripPunctuation(w).toLowerCase());
 
       // find first occurrence
       let foundAt = -1;


### PR DESCRIPTION
## Summary
- add 2,000 and 3,000 word context options
- ignore punctuation when matching quotes by adding a strip helper
- use stripped, lowercase words for search

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_684dad67d7ac832d8f0e94b737113dcc